### PR TITLE
Fix wrong overrides of virtual functions in python bindings

### DIFF
--- a/Python/Bindings/NymphPybind.cc
+++ b/Python/Bindings/NymphPybind.cc
@@ -31,7 +31,8 @@ PYBIND11_MODULE(_nymph, nymphPackage) {
     auto nymphProcessor = nymphPackage.def_submodule("processor", "Processor module");
     NymphPybind::ExportProcessor(nymphProcessor);
     NymphPybind::ExportPyProcCreator(nymphProcessor);
-    
+    NymphPybind::ExportSignalBase(nymphProcessor);
     NymphPybind::ExportSignal<Nymph::DataHandle>(nymphProcessor, "Data");
+    
     auto nymphUtility = nymphPackage.def_submodule("utility", "Utility module");
 }

--- a/Python/Bindings/Processor/ProcessorPybind.hh
+++ b/Python/Bindings/Processor/ProcessorPybind.hh
@@ -40,7 +40,7 @@ namespace NymphPybind
     {
         py::class_< Nymph::Processor, PyProcessor, std::shared_ptr<Nymph::Processor> >(nymphProcessor, "_Processor")
                 .def(py::init<const std::string& >())
-                .def("configure", &Nymph::Processor::Configure)
+                .def("Configure", &Nymph::Processor::Configure)
                 .def("connect_signal_to_slot", &Nymph::Processor::ConnectSignalToSlot)
                 .def("connect_a_slot", &Nymph::Processor::ConnectASlot)
                 .def("connect_a_signal", &Nymph::Processor::ConnectASignal)

--- a/Python/Bindings/Processor/ProcessorPybind.hh
+++ b/Python/Bindings/Processor/ProcessorPybind.hh
@@ -31,7 +31,7 @@ namespace NymphPybind
                 PYBIND11_OVERRIDE_PURE_NAME(
                     void, /* Return type */
                     Processor,      /* Parent class */
-                    configure,  /*Name of function in python*/
+                    "configure",  /*Name of function in python*/
                     Configure,          /* Name of function in C++ */
                     node/* Argument(s) */
                 );

--- a/Python/Bindings/Processor/SignalPybind.hh
+++ b/Python/Bindings/Processor/SignalPybind.hh
@@ -21,23 +21,49 @@ namespace py = pybind11;
 namespace NymphPybind
 {
     
+    //trampoline class
+    class PySignalBase : public Nymph::SignalBase {
+        public:
+            /* Inherit the constructors */
+            using Nymph::SignalBase::SignalBase;
+
+            /* Trampoline (need one for each virtual function) */
+            void Connect( Nymph::SlotBase* slot, int group = -1 ) override {
+                PYBIND11_OVERRIDE_PURE(
+                    void, /* Return type */
+                    Nymph::SignalBase,      /* Parent class */
+                    Connect,          /* Name of function in C++ (must match Python name) */
+                    slot,
+                    group/* Argument(s) */
+                );
+            }
+    };
+    
+    void ExportSignalBase( py::module_& nymphProcessor)
+    {
+
+       py::class_< Nymph::SignalBase, PySignalBase, std::shared_ptr<Nymph::SignalBase > >(nymphProcessor, "_SignalBase")
+                .def(py::init<const std::string& >())
+                .def("Connect", &Nymph::SignalBase::Connect)
+                .def("disconnect", &Nymph::SignalBase::Disconnect)
+                .def("disconnect_all", &Nymph::SignalBase::DisconnectAll)
+                .def_property_readonly("connections", static_cast< std::set< Nymph::SlotBase* >& (Nymph::SignalBase::*)() const>(&Nymph::SignalBase::Connections))
+                .def_property("name", static_cast< const std::string& (Nymph::SignalBase::*)() const>(&Nymph::SignalBase::Name),
+                                      [](Nymph::SignalBase& signal, const std::string& name){signal.Name() = name;} )
+                .def_property("do_breakpoint", &Nymph::SignalBase::GetDoBreakpoint, &Nymph::SignalBase::SetDoBreakpoint);
+        
+    }
+    
     template< typename... XArgs >
     void ExportSignal( py::module_& nymphProcessor, const std::string& typestr)
     {
         std::string pyClsName = std::string("_Signal") + typestr;
 
-       py::class_< Nymph::Signal< XArgs... >, std::shared_ptr<Nymph::Signal< XArgs... > > >(nymphProcessor, pyClsName.c_str())
+       py::class_< Nymph::Signal< XArgs... >, Nymph::SignalBase, std::shared_ptr<Nymph::Signal< XArgs... > > >(nymphProcessor, pyClsName.c_str())
                 .def(py::init<const std::string& >())
                 .def(py::init<const std::string&,  Nymph::Processor* >())
                 .def("emit", &Nymph::Signal< XArgs... >::Emit)
-                .def("__call__", &Nymph::Signal< XArgs... >::operator())
-                .def("connect", &Nymph::Signal< XArgs...>::Connect)
-                .def("disconnect", &Nymph::Signal< XArgs... >::Disconnect)
-                .def("disconnect_all", &Nymph::Signal< XArgs... >::DisconnectAll)
-                .def_property_readonly("connections", static_cast< std::set< Nymph::SlotBase* >& (Nymph::Signal< XArgs... >::*)() const>(&Nymph::Signal< XArgs... >::Connections))
-                .def_property("name", static_cast< const std::string& (Nymph::Signal< XArgs... >::*)() const>(&Nymph::Signal< XArgs... >::Name),
-                                      [](Nymph::Signal< XArgs... >& signal, const std::string& name){signal.Name() = name;} )
-                .def_property("do_breakpoint", &Nymph::Signal< XArgs... >::GetDoBreakpoint, &Nymph::Signal< XArgs... >::SetDoBreakpoint);
+                .def("__call__", &Nymph::Signal< XArgs... >::operator());
         
     }
 

--- a/Python/Bindings/Processor/SignalPybind.hh
+++ b/Python/Bindings/Processor/SignalPybind.hh
@@ -33,7 +33,7 @@ namespace NymphPybind
                 PYBIND11_OVERRIDE_PURE_NAME(
                     void, /* Return type */
                     Nymph::SignalBase,      /* Parent class */
-                    connect,            /* Name of function in python */
+                    "connect",            /* Name of function in python */
                     Connect,          /* Name of function in C++ */
                     slot,
                     group/* Argument(s) */

--- a/Testing/Python/testprocessor.py
+++ b/Testing/Python/testprocessor.py
@@ -13,7 +13,7 @@ import scarab
 
 class TestProcessor(_nymph.processor._Processor):
     
-    def configure(self, param_node):
+    def Configure(self, param_node):
         
         param_dict = param_node.to_python()
         self.x = param_dict['x']


### PR DESCRIPTION
Some missing binding code to make inheritance work properly